### PR TITLE
Cope with colon in domain identifier

### DIFF
--- a/src/kinfin.py
+++ b/src/kinfin.py
@@ -582,7 +582,7 @@ class DataFactory():
                                 if domain_source == "GO":
                                     domain_id = domain_id_count
                                 else:
-                                    domain_id, domain_count = domain_id_count.split(":")
+                                    domain_id, domain_count = domain_id_count.rsplit(":", 2)
                                 domain_counts_by_domain_id[domain_id] = int(domain_count)
                             domain_counter = Counter(domain_counts_by_domain_id)
                             domain_counter_by_domain_source[domain_source] = domain_counter


### PR DESCRIPTION
This allows using kinfin with the PANTHER or Gene3D databases which
output entries like:

PTHR10513:SF25:1;PTHR10513:1	G3DSA:3.40.50.300:1